### PR TITLE
Added Gemini 2.5 Flash-Lite Preview

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -40,6 +40,7 @@
 				{"text": "Gemini 2.0 Flash (Fast & Balanced)", "value": "gemini-2.0-flash"},
 				{"text": "Gemini 2.5 Flash Preview 04-17 (Fast & Capable)", "value": "gemini-2.5-flash-preview-04-17"},
 				{"text": "Gemini 2.5 Flash Preview 05-20 (Fast & Capable)", "value": "gemini-2.5-flash-preview-05-20"},
+				{"text": "Gemini 2.5 Flash-Lite Preview (Fast & Lightweight)", "value": "gemini-2.5-flash-lite-preview-06-17"},
 				{"text": "Gemini 2.0 Pro Exp (Enhanced, Slower)", "value": "gemini-2.0-pro-exp"},
 				{"text": "Gemini 2.5 Pro Exp (Advanced, Slowest)", "value": "gemini-2.5-pro-exp-03-25"},
 				{"text": "Gemma 3n (Open source, Fast)", "value": "gemma-3n-e4b-it"},


### PR DESCRIPTION
• Added Gemini 2.5 Flash-Lite Preview model option to the extension
    • New model ID: gemini-2.5-flash-lite-preview-06-17
    • Its the new best 'lite' model from gemini, the current repo only had the [Gemini 2.0 Flash-Lite](https://ai.google.dev/gemini-api/docs/models#gemini-2.0-flash-lite)
    
    [Gemini 2.5 Flash-Lite Preview](https://ai.google.dev/gemini-api/docs/models#gemini-2.5-flash-lite) has been called "Most cost-efficient model supporting high throughput", so it would be good to add 
  this as people use this tool using their api key
